### PR TITLE
Return the buffer from .screenshot() in case we don't want to save image

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ nodeHtmlToImage({
 })
 ```
 
-### Using the buffer
+### Using the buffer instead of saving to disk
 
-If you don't want to save the image to disk and would rather do something with it immediately, you can use the return value instead! The example below shows how you can generate an image and send it back to a client via ExpressJS.
+If you don't want to save the image to disk and would rather do something with it immediately, you can use the returned value instead! The example below shows how you can generate an image and send it back to a client via using [express](https://github.com/expressjs/express).
 
 ```js
 const express = require('express');

--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ nodeHtmlToImage({
 })
 ```
 
+### Using the buffer
+
+If you don't want to save the image to disk and would rather do something with it immediately, you can use the return value instead! The example below shows how you can generate an image and send it back to a client via ExpressJS.
+
+```js
+const express = require('express');
+const router = express.Router();
+const nodeHtmlToImage = require('node-html-to-image');
+
+router.get(`/api/tweet/render`, async function(req, res) {
+  const image = await nodeHtmlToImage({
+    html: '<html><body><div>Check out what I just did! #cool</div></body></html>'
+  });
+  res.writeHead(200, { 'Content-Type': 'image/png' });
+  res.end(imgBinary, 'binary');
+});
+```
+
 ## Related
 
 - [node-html-to-image-cli](https://github.com/frinyvonnick/node-html-to-image-cli) - CLI for this module

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,10 @@ module.exports = async function({
   if (content) {
     const template = handlebars.compile(html)
     html = template(content, { waitUntil })
-  } 
+  }
   await page.setContent(html)
   const element = await page.$('body')
-  await element.screenshot({ path: output, type, omitBackground: transparent })
+  const buffer = await element.screenshot({ path: output, type, omitBackground: transparent })
   await browser.close()
+  return buffer
 }


### PR DESCRIPTION
.screenshot() returns a buffer and for our use case, we want to immediately return the image through our server and never store it

See: https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagescreenshotoptions