### PR TITLE
:bug: Pass waitUntil option to setContent method

### DIFF
--- a/src/screenshot.js
+++ b/src/screenshot.js
@@ -9,7 +9,7 @@ module.exports = {
     content,
     html,
     transparent = false,
-    waitUntil = 'load',
+    waitUntil = 'networkidle0',
   }) {
     let screeshotArgs = {}
     if (type === 'jpeg') {
@@ -18,9 +18,9 @@ module.exports = {
 
     if (content) {
       const template = handlebars.compile(html)
-      html = template(content, { waitUntil })
+      html = template(content)
     }
-    await page.setContent(html)
+    await page.setContent(html, { waitUntil })
     const element = await page.$('body')
     const buffer = await element.screenshot({ path: output, type, omitBackground: transparent, encoding, ...screeshotArgs })
 


### PR DESCRIPTION
Fix #33 

To test install the right revision of the module with:
```
yarn add https://github.com/frinyvonnick/node-html-to-image.git#bug-wait-until
```

Use the `waitUntil` option valued to `networkidle0` in order to wait for all ressources to be loaded.

```js
const nodeHtmlToImage = require("node-html-to-image");

nodeHtmlToImage({
  output: './image.png',
  waitUntil: 'networkidle0',
  html: `<html>
  <head>
    <link
      href="https://fonts.googleapis.com/css?family=Poppins:400,700,900"
      rel="stylesheet"
    />
    <style>
      body {
        font-family: "Poppins";
        font-weight: 700;
      }

      img {
        max-width: 100%;
      }
    </style>
  </head>
  <body>
    Hello world 🙌!
    <img src="https://img.webmd.com/dtmcms/live/webmd/consumer_assets/site_images/article_thumbnails/other/cat_relaxing_on_patio_other/1800x1200_cat_relaxing_on_patio_other.jpg" />
  </body>
</html>`
})
  .then(() => console.log('The image was created successfully!'))
```