### PR TITLE
📦 clean published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
   "scripts": {
     "test": "jest"
   },
+  "files": [
+    "src",
+    "!src/*.spec.js",
+    "example.js"
+  ],
   "devDependencies": {
     "gitmoji-changelog": "^2.1.0",
     "jest": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "files": [
     "src",
-    "!src/*.spec.js",
-    "example.js"
+    "!src/*.spec.js"
   ],
   "devDependencies": {
     "gitmoji-changelog": "^2.1.0",


### PR DESCRIPTION
This is the first PR of 3 to supersede #42

This PR will clean the published files. In particular the `jest.config.js` and test files were being published to NPM.

<details><summary><b>Before:</b></summary>

```sh
❯ npm publish --dry-run
npm notice 
npm notice package: node-html-to-image@3.0.0
npm notice === Tarball Contents ===
npm notice 11.4kB LICENSE
npm notice 217B   example.js
npm notice 1.1kB  src/index.js
npm notice 3.8kB  src/index.spec.js
npm notice 6.3kB  jest.config.js
npm notice 694B   src/screenshot.js
npm notice 1.5kB  src/screenshot.spec.js
npm notice 597B   package.json
npm notice 6.5kB  CHANGELOG.md
npm notice 8.6kB  README.md
npm notice === Tarball Details ===
npm notice name:          node-html-to-image
npm notice version:       3.0.0
npm notice package size:  13.0 kB
npm notice unpacked size: 40.6 kB
npm notice shasum:        ab5e3a69823ead7bbc8589034dbfad784e83d4c7
npm notice integrity:     sha512-Pp5DckzsaD07+[...]rStuXlTA6XxZg==
npm notice total files:   10
npm notice
+ node-html-to-image@3.0.0
```

</details>

<details><summary><b>After:</b></summary>

```sh
❯ npm publish --dry-run
npm notice 
npm notice package: node-html-to-image@3.0.0
npm notice === Tarball Contents ===
npm notice 11.4kB LICENSE
npm notice 217B   example.js       
npm notice 1.1kB  src/index.js
npm notice 694B   src/screenshot.js
npm notice 665B   package.json
npm notice 6.5kB  CHANGELOG.md
npm notice 8.6kB  README.md
npm notice === Tarball Details ===
npm notice name:          node-html-to-image
npm notice version:       3.0.0
npm notice package size:  9.8 kB
npm notice unpacked size: 29.1 kB
npm notice shasum:        4194e3775a17bec10928d3d09e42c365852bd068
npm notice integrity:     sha512-NTQmg5CJUJcYO[...]65JoF3Vy0gC1Q==
npm notice total files:   7
npm notice
+ node-html-to-image@3.0.0
```

</details>

The difference is the tarball going from 13.0 kB to 9.8 kB (or 40.6 kB to 29.1 kB unpacked). Worth the difference ;)!