### PR TITLE
🏷 Add TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ yarn add node-html-to-image
 ## Usage
 
 - [Simple example](#simple-example)
+- [TypeScript Support](#typescript-support)
 - [Options](#options)
 - [Setting output image resolution](#setting-output-image-resolution)
 - [Example with Handlebars](#example-with-handlebars)
@@ -49,6 +50,14 @@ nodeHtmlToImage({
   html: '<html><body>Hello world!</body></html>'
 })
   .then(() => console.log('The image was created successfully!'))
+```
+
+### TypeScript support
+
+Types are included in the package. Enable the `esModuleInterop` compiler flag then change all references of `require` with `import` statements and you should be good to go:
+
+```ts
+import nodeHtmlToImage from 'node-html-image'
 ```
 
 ### Options

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "A Node.js library that generates images from HTML",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "repository": "git@github.com:frinyvonnick/node-html-to-image.git",
   "author": "FRIN Yvonnick <frin.yvonnick@gmail.com>",
   "license": "Apache-2.0",
@@ -14,6 +15,12 @@
   "scripts": {
     "test": "jest"
   },
+  "files": [
+    "src",
+    "types",
+    "!src/*.spec.js",
+    "example.js"
+  ],
   "devDependencies": {
     "gitmoji-changelog": "^2.1.0",
     "jest": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "files": [
     "src",
     "types",
-    "!src/*.spec.js",
-    "example.js"
+    "!src/*.spec.js"
   ],
   "devDependencies": {
     "gitmoji-changelog": "^2.1.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="node" />
+
+import { NodeHtmlToImageOptions } from './options';
+
+/**
+ * `node-html-to-image` takes a screenshot of the body tag's content.
+ * @param options Options to pass to the generatorr
+ */
+declare function nodeHtmlToImage(options: NodeHtmlToImageOptions): Promise<string | Buffer | (string | Buffer)[]>;
+export default nodeHtmlToImage;
+export * from './options';

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,0 +1,49 @@
+import type { LaunchOptions, LoadEvent } from 'puppeteer';
+
+/**
+ * Available options to pass to the library
+ */
+export interface NodeHtmlToImageOptions {
+    /**
+     * The html used to generate image content
+     */
+    html: string;
+    /**
+     * The ouput path for generated image
+     * If none is specified
+     */
+    output?: string;
+    /**
+     * The type of the generated image
+     * @default png
+     */
+    type?: 'jpeg' | 'png';
+    /**
+     * The quality of the generated image (only applicable to jpg)
+     * @default 80
+     */
+    quality?: number;
+    /**
+     * If provided html property is considered an handlebars template and use content value to fill it
+     */
+    content?: Array<unknown> | Record<string, any>;
+    /**
+     * Define when to consider markup succeded.
+     * {@link https://github.com/puppeteer/puppeteer/blob/8370ec88ae94fa59d9e9dc0c154e48527d48c9fe/docs/api.md#pagesetcontenthtml-options Learn more}
+     */
+    waitUntil?: LoadEvent;
+    /**
+     * The puppeteerArgs property let you pass down custom configuration to puppeteer.
+     * {@link https://github.com/puppeteer/puppeteer/blob/8370ec88ae94fa59d9e9dc0c154e48527d48c9fe/docs/api.md#puppeteerlaunchoptions Learn more}
+     */
+    puppeteerArgs?: LaunchOptions;
+    /**
+     * The transparent property lets you generate images with transparent background (for png type).
+     */
+    transparent?: boolean;
+    /**
+     * The encoding property of the image. Options are `binary` (default) or `base64`.
+     * @default binary
+     */
+    encoding?: 'binary' | 'base64';
+}

--- a/types/screenshot.d.ts
+++ b/types/screenshot.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="node" />
+import type { Page } from 'puppeteer';
+import type { NodeHtmlToImageOptions } from './options';
+
+declare function makeScreenshot(page: Page, { output, type, quality, encoding, content, html, transparent, waitUntil }: NodeHtmlToImageOptions): Promise<string | Buffer>;
+export default makeScreenshot;


### PR DESCRIPTION
This is the third PR of 3 to supersede #42

This PR adds TypeScript types to the package. It should be noted that this closes #43 as the types of course also have to be included in the bundle and I figured this would be the cleanest way to make the PRs not conflict.

That is to say, if you first merge #43 then I don't think this PR will have any merge conflicts.

<details><summary><b>After (with types):</b></summary>

```sh
❯ npm publish --dry-run
npm notice 
npm notice package: node-html-to-image@3.0.0
npm notice === Tarball Contents === 
npm notice 11.4kB LICENSE
npm notice 217B   example.js
npm notice 1.1kB  src/index.js
npm notice 694B   src/screenshot.js    
npm notice 709B   package.json
npm notice 6.5kB  CHANGELOG.md
npm notice 8.6kB  README.md
npm notice 388B   types/index.d.ts     
npm notice 1.6kB  types/options.d.ts   
npm notice 329B   types/screenshot.d.ts
npm notice === Tarball Details === 
npm notice name:          node-html-to-image
npm notice version:       3.0.0
npm notice package size:  10.4 kB
npm notice unpacked size: 31.4 kB
npm notice shasum:        76a1e6f27843cb448f58c0bc4aa79e7746208387
npm notice integrity:     sha512-zooAzLxUpYhIT[...]U2qPzN5wu+0bg==
npm notice total files:   10
npm notice 
+ node-html-to-image@3.0.0
```

</details>