### PR TITLE
Support an instance mode for node-html-to-image

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,16 @@
 /// <reference types="node" />
 
-import { NodeHtmlToImageOptions } from './options';
+import { NodeHtmlToImageConstructorOptions, NodeHtmlToImageOptions } from './options';
 
 /**
  * `node-html-to-image` takes a screenshot of the body tag's content.
  * @param options Options to pass to the generatorr
  */
-declare function nodeHtmlToImage(options: NodeHtmlToImageOptions): Promise<string | Buffer | (string | Buffer)[]>;
+declare function nodeHtmlToImage(options: NodeHtmlToImageConstructorOptions): NodeHtmlToImageInstance;
+
+export interface NodeHtmlToImageInstance {
+  render(options: NodeHtmlToImageOptions): Promise<string | Buffer | (string | Buffer)[]>;
+}
+
 export default nodeHtmlToImage;
 export * from './options';

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,5 +1,13 @@
 import type { LaunchOptions, LoadEvent } from 'puppeteer';
 
+export interface NodeHtmlToImageConstructorOptions {
+  /**
+   * The puppeteerArgs property let you pass down custom configuration to puppeteer.
+   * {@link https://github.com/puppeteer/puppeteer/blob/8370ec88ae94fa59d9e9dc0c154e48527d48c9fe/docs/api.md#puppeteerlaunchoptions Learn more}
+   */
+  puppeteerArgs?: LaunchOptions;
+}
+
 /**
  * Available options to pass to the library
  */
@@ -32,11 +40,6 @@ export interface NodeHtmlToImageOptions {
    * {@link https://github.com/puppeteer/puppeteer/blob/8370ec88ae94fa59d9e9dc0c154e48527d48c9fe/docs/api.md#pagesetcontenthtml-options Learn more}
    */
   waitUntil?: LoadEvent;
-  /**
-   * The puppeteerArgs property let you pass down custom configuration to puppeteer.
-   * {@link https://github.com/puppeteer/puppeteer/blob/8370ec88ae94fa59d9e9dc0c154e48527d48c9fe/docs/api.md#puppeteerlaunchoptions Learn more}
-   */
-  puppeteerArgs?: LaunchOptions;
   /**
    * Function executes before screenshot is taken and provides access to puppeteer page element
    */


### PR DESCRIPTION
**This is a breaking API change (for now)**

node-html-to-image's default export is now a function which returns an
instance object with a render() method which is the old
nodeHtmlToImage() functionality. The reason for doing this is to allow
us to instantiate a single 'image maker' object that we call render() on
multiple times and reuse the same puppeteer cluster.

In addition,
* Update the type definitions.
* Use Cluster.execute() instead of Cluster.queue() plus Cluster.idle()
  as this will allow better use in concurrent situations. We will only
  wait for our jobs to finish rather than for the entire cluster to go
  idle.

Fixes frinyvonnick/node-html-to-image#80