### PR TITLE
Changed typescript definitions and changed export system for index.js

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-const nodeHtmlToImage = require('./src/index.js')
+const {nodeHtmlToImage} = require('./src/index.js')
 
 nodeHtmlToImage({
   output: './image.png',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "!src/*.spec.js"
   ],
   "devDependencies": {
+    "@types/node": "^16.10.1",
     "gitmoji-changelog": "^2.1.0",
     "jest": "^26.1.0",
     "jest-circus": "^26.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const { Cluster } = require('puppeteer-cluster')
 
 const { makeScreenshot } = require('./screenshot.js')
 
-module.exports = async function(options) {
+const nodeHtmlToImage = async function(options) {
   const {
     html,
     content,
@@ -45,6 +45,9 @@ module.exports = async function(options) {
   await cluster.close();
 
   return shouldBatch ? buffers : buffers[0]
- 
 }
 
+module.exports = {
+  default: nodeHtmlToImage,
+  nodeHtmlToImage,
+}

--- a/types/screenshot.d.ts
+++ b/types/screenshot.d.ts
@@ -2,5 +2,4 @@
 import type { Page } from 'puppeteer';
 import type { NodeHtmlToImageOptions } from './options';
 
-declare function makeScreenshot(page: Page, { output, type, quality, encoding, content, html, beforeScreenshot, transparent, waitUntil, selector }: NodeHtmlToImageOptions): Promise<string | Buffer>;
-export default makeScreenshot;
+export declare function makeScreenshot(page: Page, { output, type, quality, encoding, content, html, beforeScreenshot, transparent, waitUntil, selector }: NodeHtmlToImageOptions): Promise<string | Buffer>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -619,6 +619,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
   integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
 
+"@types/node@^16.10.1":
+  version "16.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.1.tgz#f3647623199ca920960006b3dccf633ea905f243"
+  integrity sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
# Pull Request
## Changes:
Now module exports function as __ES6__ default export and, also, with ```nodeHtmlToImage``` name. Example file changed to fit new structure.
