### PR TITLE
🔧 Add check for empty content object

### DIFF
--- a/src/screenshot.js
+++ b/src/screenshot.js
@@ -18,7 +18,7 @@ module.exports = {
       screeshotArgs.quality = quality ? quality : 80
     }
 
-    if (content) {
+    if (content && !(Object.keys(content).length === 0 && Object.getPrototypeOf(content) === Object.prototype)) {
       const template = handlebars.compile(html)
       html = template(content)
     }


### PR DESCRIPTION
The content property was being overwritten with an empty object, which is truthy. This resulted in a Handlebars compilation regardless of whether a content property was specified. This fixes the issue by adding an extra check to make sure that content isn't simply an empty object.