### PR TITLE
:bug: Prevent handlebar to compile template if content is empty

### DIFF
--- a/src/models/Screenshot.spec.ts
+++ b/src/models/Screenshot.spec.ts
@@ -112,6 +112,15 @@ describe("Screenshot", () => {
     expect(screenshot.quality).toEqual(undefined);
   });
 
+  it("should handle empty content", () => {
+    const screenshot = new Screenshot({
+      html,
+      content: {},
+    });
+
+    expect(screenshot.content).toEqual(undefined);
+  });
+
   it("should set quality if type is jpeg", () => {
     const screenshot = new Screenshot({
       html,

--- a/src/models/Screenshot.ts
+++ b/src/models/Screenshot.ts
@@ -32,7 +32,7 @@ export class Screenshot {
     this.transparent = transparent;
     this.type = type;
     this.output = output;
-    this.content = content;
+    this.content = isEmpty(content) ? undefined : content;
     this.selector = selector;
     this.quality = type === "jpeg" ? quality : undefined;
   }
@@ -47,4 +47,8 @@ export class Screenshot {
   setBuffer(buffer: Buffer | string) {
     this.buffer = buffer;
   }
+}
+
+function isEmpty(val: object) {
+  return val == null || !Object.keys(val).length;
 }

--- a/src/screenshot.spec.ts
+++ b/src/screenshot.spec.ts
@@ -49,6 +49,20 @@ describe("beforeScreenshot", () => {
     );
   });
 
+  it("should not compile a screenshot if content is empty", async () => {
+    await makeScreenshot(page, {
+      screenshot: new Screenshot({
+        html: "<html><body>{{message}}</body></html>",
+        content: {},
+      }),
+    });
+
+    expect(page.setContent).toHaveBeenCalledWith(
+      "<html><body>{{message}}</body></html>",
+      expect.anything()
+    );
+  });
+
   it("should wait until load event", async () => {
     await makeScreenshot(page, {
       screenshot: new Screenshot({


### PR DESCRIPTION
Fix #147 