### PR TITLE
➕ Extending options to allow configuration of puppeteer cluster timeout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,9 @@ export async function nodeHtmlToImage(options: Options) {
 
   const cluster: Cluster<ScreenshotParams> = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
-    maxConcurrency: 2,
+    maxConcurrency: options.maxConcurrency ?? 2,
     puppeteerOptions: { ...puppeteerArgs, headless: true },
+    timeout: options.browserTimeout ?? 30000,
     puppeteer: puppeteer,
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export interface ScreenshotParams {
 
 export interface Options extends ScreenshotParams {
   puppeteerArgs?: PuppeteerNodeLaunchOptions;
+  browserTimeout?: number;
+  maxConcurrency?: number;
   // https://github.com/thomasdondorf/puppeteer-cluster/blob/b5b098aed84b8d2c170b3f9d0ac050f53582df45/src/Cluster.ts#L30
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   puppeteer?: any,


### PR DESCRIPTION
This PR adds support for configuring the browser timeout of the puppeteer cluster, this is extremely important for some larger renders.

This should fix issues like issue #164 by allowing the developer to configure the max allowed time to render the page.