### PR TITLE
Move element selection to after `beforeScreenshot` hook

### DIFF
--- a/src/screenshot.spec.ts
+++ b/src/screenshot.spec.ts
@@ -26,6 +26,21 @@ describe("beforeScreenshot", () => {
     expect(beforeScreenshot).toHaveBeenCalledWith(page);
   });
 
+  it("should selected element after calling beforeScreenshot", async () => {
+    const beforeScreenshot = jest.fn();
+    await makeScreenshot(page, {
+      beforeScreenshot,
+      screenshot: new Screenshot({
+        html: `<html><body>Hello world!</body></html>`,
+      }),
+    });
+
+    const beforeScreenshotOrder = beforeScreenshot.mock.invocationCallOrder[0];
+    const selectElementOrder = page.$.mock.invocationCallOrder[0];
+
+    expect(selectElementOrder).toBeGreaterThan(beforeScreenshotOrder);
+  });
+
   it("should return a screenshot with a buffer", async () => {
     const screenshot = await makeScreenshot(page, {
       screenshot: new Screenshot({

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -32,13 +32,14 @@ export async function makeScreenshot(
   }
 
   await page.setContent(screenshot.html, { waitUntil });
-  const element = await page.$(screenshot.selector);
-  if (!element) {
-    throw Error("No element matches selector: " + screenshot.selector);
-  }
 
   if (isFunction(beforeScreenshot)) {
     await beforeScreenshot(page);
+  }
+
+  const element = await page.$(screenshot.selector);
+  if (!element) {
+    throw Error("No element matches selector: " + screenshot.selector);
   }
 
   const buffer = await element.screenshot({

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,12 @@ export interface Options extends ScreenshotParams {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   puppeteer?: any,
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-  beforeScreenshot?: (page: Page) => void;
+  beforeScreenshot?: (page: Page) => Promise<void>;
 }
 
 export interface MakeScreenshotParams {
   screenshot: Screenshot;
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-  beforeScreenshot?: (page: Page) => void;
+  beforeScreenshot?: (page: Page) => Promise<void>;
   handlebarsHelpers?: { [helpers: string]: (...args: any[]) => any };
 }


### PR DESCRIPTION
Hello, first of all, great package!

This lets you manipulate content and elements in `beforeScreenshot`, without errors due to unmounting the already selected element.

In my use case I need to disable Javascript that comes with the HTML and I want to be able to do something like this:
```ts
beforeScreenshot: async page => {
  await page.setJavaScriptEnabled(false)
  await page.setContent(html)
},
```

Right now this doesn't work since the element is selected beforehand and the reference is pointing to an unmounted element.