### PR TITLE
Bypass allowPrototypeMethod via @handlebars/allow-prototype-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+<a name="3.3.0a"></a>
+## 3.3.0a (2023-03-29)
+
+### Added
+
+- ✨ Add @handlebars/allow-prototype-access to bypass handlebars proto method errors, when the function in core doens't work. 
+
 <a name="3.3.0"></a>
 ## 3.3.0 (2022-08-31)
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "FRIN Yvonnick <frin.yvonnick@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@handlebars/allow-prototype-access": "^1.0.5",
     "handlebars": "^4.5.3",
     "puppeteer": "^15.3.0",
     "puppeteer-cluster": "^0.23.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ export async function nodeHtmlToImage(options: Options) {
     quality,
     puppeteerArgs = {},
     puppeteer = undefined,
+    insecurePrototype
   } = options;
 
   const cluster: Cluster<ScreenshotParams> = await Cluster.launch({
@@ -42,6 +43,7 @@ export async function nodeHtmlToImage(options: Options) {
             selector: contentSelector ? contentSelector : selector,
             type,
             quality,
+            insecurePrototype
           },
           async ({ page, data }) => {
             const screenshot = await makeScreenshot(page, {

--- a/src/screenshot.spec.ts
+++ b/src/screenshot.spec.ts
@@ -472,5 +472,24 @@ describe("handlebarsHelpers", () => {
         expect.anything()
       );
     });
+
+    it("should bypass proto/method error", async () => {
+      await makeScreenshot(page, {
+        screenshot: new Screenshot({
+          html: "<html><body>{{message.content}}</body></html>",
+          content: {
+            message: {
+              content: "Hello World!"
+            }
+          },
+          insecurePrototype: true
+        })
+      });
+
+      expect(page.setContent).toHaveBeenCalledWith(
+        "<html><body>Hello World!</body></html>",
+        expect.anything()
+      );
+    });
   });
 });

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -1,5 +1,8 @@
+import { allowInsecurePrototypeAccess } from '@handlebars/allow-prototype-access';
 import { Page } from "puppeteer";
-import handlebars, { compile } from "handlebars";
+import hndl, { compile } from "handlebars";
+
+const handlebars = allowInsecurePrototypeAccess(hndl);
 
 import { MakeScreenshotParams } from "./types";
 

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -2,8 +2,6 @@ import { allowInsecurePrototypeAccess } from '@handlebars/allow-prototype-access
 import { Page } from "puppeteer";
 import hndl, { compile } from "handlebars";
 
-const handlebars = allowInsecurePrototypeAccess(hndl);
-
 import { MakeScreenshotParams } from "./types";
 
 export async function makeScreenshot(
@@ -13,8 +11,12 @@ export async function makeScreenshot(
     beforeScreenshot,
     waitUntil = "networkidle0",
     handlebarsHelpers,
+    insecurePrototype
   }: MakeScreenshotParams
 ) {
+  let handlebars;
+  if (insecurePrototype) handlebars = allowInsecurePrototypeAccess(hndl);
+  else handlebars = hndl;
   const hasHelpers = handlebarsHelpers && typeof handlebarsHelpers === "object";
   if (hasHelpers) {
     if (

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -1,6 +1,6 @@
 import { allowInsecurePrototypeAccess } from '@handlebars/allow-prototype-access';
 import { Page } from "puppeteer";
-import hndl, { compile } from "handlebars";
+import hndl from "handlebars";
 
 import { MakeScreenshotParams } from "./types";
 
@@ -32,7 +32,7 @@ export async function makeScreenshot(
 
 
   if (screenshot?.content || hasHelpers) {
-    const template = compile(screenshot.html);
+    const template = handlebars.compile(screenshot.html);
     screenshot.setHTML(template(screenshot.content));
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface ScreenshotParams {
   selector?: string;
   content?: Content;
   output?: string;
-  insecurePrototype: boolean;
+  insecurePrototype?: boolean;
 }
 
 export interface Options extends ScreenshotParams {
@@ -31,5 +31,5 @@ export interface MakeScreenshotParams {
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
   beforeScreenshot?: (page: Page) => void;
   handlebarsHelpers?: { [helpers: string]: (...args: any[]) => any };
-  insecurePrototype: boolean;
+  insecurePrototype?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface ScreenshotParams {
   selector?: string;
   content?: Content;
   output?: string;
+  insecurePrototype: boolean;
 }
 
 export interface Options extends ScreenshotParams {
@@ -30,4 +31,5 @@ export interface MakeScreenshotParams {
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
   beforeScreenshot?: (page: Page) => void;
   handlebarsHelpers?: { [helpers: string]: (...args: any[]) => any };
+  insecurePrototype: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,6 +988,11 @@
     lodash "^4.17.11"
     semver "^5.6.0"
 
+"@handlebars/allow-prototype-access@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@handlebars/allow-prototype-access/-/allow-prototype-access-1.0.5.tgz#364384d1879765aad210a61becd849afab3954b3"
+  integrity sha512-D5AJO9dM6B+1scVVQ4ma05cAku5M2dEnlycggIg6RW539TdQlgbNg1G1r86fNqqNI0CHv/TVwKEB9M6ILJQCWQ==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
**Adding repo with @handlebars/allow-prototype-access**

There isn't a option in main branch to change the `allowProtoMethodsByDefault` via `nodeHtmlToImage` function.
My version is adding option to `nodeHtmlToImage` function to bypass it with this library.

I don't know why, but `{{#with method}}` doesn't work either, so I need to rebuilt it for my own purposes. Just remember - use it only if you know that, users won't have a access for security reasons.

Just add option to your main function:
```js
{
     insecurePrototype: true;
}
```