### PR TITLE
puppeteer_deprecation_issue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export async function nodeHtmlToImage(options: Options) {
   const cluster: Cluster<ScreenshotParams> = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
     maxConcurrency: 2,
-    puppeteerOptions: { ...puppeteerArgs, headless: true },
+    puppeteerOptions: { ...puppeteerArgs, headless: "new" },
     puppeteer: puppeteer,
   });
 


### PR DESCRIPTION
there is deprecation warning issue with puppeteer headless mode

headless : true will be deprecated,
"new" will replace true