### PR TITLE
📝 Update sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ const dataURI = 'data:image/jpeg;base64,' + base64Image
 
 nodeHtmlToImage({
   output: './image.png',
-  html: '<html><body><img src="{{imageSource}}" /></body></html>',
+  html: '<html><body><img src="{{{imageSource}}}" /></body></html>',
   content: { imageSource: dataURI }
 })
 ```
@@ -184,7 +184,7 @@ const html = `
     <style>
       @font-face {
         font-family: 'testFont';
-        src: url(${_data}) format('woff2'); // don't forget the format!
+        src: url("{{{_data}}}") format('woff2'); // don't forget the format!
       }
     </style>
   </head>


### PR DESCRIPTION
The sample code given in the readme may not work if the encoded base64 includes `=` which handlebars.js gladly escapes to `&#x3D;`

Updated sample code in readme to insert base64 content unescaped https://handlebarsjs.com/guide/#html-escaping

Here is a sample image to test on:
![beidou](https://github.com/frinyvonnick/node-html-to-image/assets/41858005/c2e01bae-3386-4c55-89f9-fa8029175d24)
