### PR TITLE
Stricter typing, prevent force exit of systems, return string for base64 encoding etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jest": "^28.1.2",
     "jest-circus": "^28.1.2",
     "puppeteer-core": "23.2.2",
-    "rimraf": "^3.0.2",
+    "rimraf": "^6.0.1",
     "tesseract.js": "4.1.1",
     "typescript": "^4.7.4"
   }

--- a/src/main.integration.spec.ts
+++ b/src/main.integration.spec.ts
@@ -7,43 +7,26 @@ import { createWorker } from "tesseract.js";
 import { nodeHtmlToImage } from "./main";
 
 describe("node-html-to-image", () => {
-  let mockExit: jest.SpyInstance;
-  let mockConsoleErr: jest.SpyInstance;
-  const originalConsoleError = console.error;
   beforeEach(() => {
     rimraf.sync("./generated");
     mkdirSync("./generated");
-    mockExit = jest.spyOn(process, "exit").mockImplementation((number) => {
-      throw new Error("process.exit: " + number);
-    });
-    mockConsoleErr = jest
-      .spyOn(console, "error")
-      .mockImplementation((value) => originalConsoleError(value));
-  });
-
-  afterEach(() => {
-    mockExit.mockRestore();
-    mockConsoleErr.mockRestore();
   });
 
   afterAll(() => {
     rimraf.sync("./generated");
   });
   describe("error", () => {
-    it("should stop the program properly", async () => {
-      /* eslint-disable @typescript-eslint/ban-ts-comment */
+    it("should throw due to invalid quality parameter", async () => {
       await expect(async () => {
         await nodeHtmlToImage({
           html: "<html></html>",
           type: "jpeg",
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           quality: "wrong value",
           puppeteerArgs: { args: ['--no-sandbox'] }
         });
       }).rejects.toThrow();
-
-      expect(mockExit).toHaveBeenCalledWith(1);
-      /* eslint-enable @typescript-eslint/ban-ts-comment */
     });
   });
 
@@ -86,10 +69,7 @@ describe("node-html-to-image", () => {
           output: "./generated/image.png",
           puppeteerArgs: { args: ['--no-sandbox'] }
         });
-      }).rejects.toThrow();
-      expect(mockConsoleErr).toHaveBeenCalledWith(
-        new Error("You must provide an html property.")
-      );
+      }).rejects.toThrow("You must provide an html property.");
     });
 
     it("should throw timeout error", async () => {
@@ -99,10 +79,7 @@ describe("node-html-to-image", () => {
           html: "<html></html>",
           puppeteerArgs: { args: ['--no-sandbox'] }
         });
-      }).rejects.toThrow();
-      expect(mockConsoleErr).toHaveBeenCalledWith(
-        new Error("Timeout hit: 500")
-      );
+      }).rejects.toThrow("Timeout hit: 500");
     });
 
     it("should generate an jpeg image and return Buffer", async () => {

--- a/src/main.integration.spec.ts
+++ b/src/main.integration.spec.ts
@@ -48,14 +48,15 @@ describe("node-html-to-image", () => {
   });
 
   describe("single image", () => {
-    it("should generate output file", async () => {
-      await nodeHtmlToImage({
+    it("should generate output file and return Buffer", async () => {
+      const imageBuffer = await nodeHtmlToImage({
         output: "./generated/image.png",
         html: "<html></html>",
         puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(existsSync("./generated/image.png")).toBe(true);
+      expect(imageBuffer).toBeInstanceOf(Buffer);
     });
 
     it("should return a buffer", async () => {
@@ -65,6 +66,16 @@ describe("node-html-to-image", () => {
       });
 
       expect(result).toBeInstanceOf(Buffer);
+    });
+
+    it("should return a base64 string", async () => {
+      const result = await nodeHtmlToImage({
+        html: "<html></html>",
+        encoding: "base64",
+        puppeteerArgs: { args: ['--no-sandbox'] }
+      });
+
+      expect(typeof result).toBe('string');
     });
 
     it("should throw an error if html is not provided", async () => {
@@ -94,8 +105,8 @@ describe("node-html-to-image", () => {
       );
     });
 
-    it("should generate an jpeg image", async () => {
-      await nodeHtmlToImage({
+    it("should generate an jpeg image and return Buffer", async () => {
+      const imageBuffer = await nodeHtmlToImage({
         output: "./generated/image.jpg",
         html: "<html></html>",
         type: "jpeg",
@@ -103,6 +114,7 @@ describe("node-html-to-image", () => {
       });
 
       expect(existsSync("./generated/image.jpg")).toBe(true);
+      expect(imageBuffer).toBeInstanceOf(Buffer);
     });
 
     it("should put html in output file", async () => {
@@ -143,8 +155,8 @@ describe("node-html-to-image", () => {
   });
 
   describe("batch", () => {
-    it("should create two images", async () => {
-      await nodeHtmlToImage({
+    it("should create two images and return two Buffers", async () => {
+      const imageBuffers = await nodeHtmlToImage({
         type: "png",
         quality: 300,
         html: "<html><body>Hello {{name}}!</body></html>",
@@ -154,6 +166,14 @@ describe("node-html-to-image", () => {
         ],
         puppeteerArgs: { args: ['--no-sandbox'] }
       });
+
+      expect(imageBuffers?.length).toBe(2);
+
+      const buffer1 = imageBuffers?.[0];
+      const buffer2 = imageBuffers?.[1];
+
+      expect(buffer1).toBeInstanceOf(Buffer);
+      expect(buffer2).toBeInstanceOf(Buffer);
 
       const text1 = await getTextFromImage("./generated/image1.png");
       expect(text1.trim()).toBe("Hello Yvonnick!");
@@ -223,7 +243,7 @@ describe("node-html-to-image", () => {
         output: "./generated/image.png",
         html: "<html></html>",
         puppeteerArgs: { executablePath, args: ['--no-sandbox'] },
-        puppeteer: puppeteerCore
+        puppeteer: puppeteerCore,
       });
 
       expect(existsSync("./generated/image.png")).toBe(true);

--- a/src/main.integration.spec.ts
+++ b/src/main.integration.spec.ts
@@ -1,14 +1,14 @@
 import { existsSync, mkdirSync, readdirSync } from "fs";
 import puppeteer from "puppeteer";
 import puppeteerCore from "puppeteer-core";
-import rimraf from "rimraf";
+import * as rimraf from "rimraf";
 import { createWorker } from "tesseract.js";
 
 import { nodeHtmlToImage } from "./main";
 
 describe("node-html-to-image", () => {
-  let mockExit;
-  let mockConsoleErr;
+  let mockExit: jest.SpyInstance;
+  let mockConsoleErr: jest.SpyInstance;
   const originalConsoleError = console.error;
   beforeEach(() => {
     rimraf.sync("./generated");
@@ -38,6 +38,7 @@ describe("node-html-to-image", () => {
           type: "jpeg",
           // @ts-ignore
           quality: "wrong value",
+          puppeteerArgs: { args: ['--no-sandbox'] }
         });
       }).rejects.toThrow();
 
@@ -51,6 +52,7 @@ describe("node-html-to-image", () => {
       await nodeHtmlToImage({
         output: "./generated/image.png",
         html: "<html></html>",
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(existsSync("./generated/image.png")).toBe(true);
@@ -59,6 +61,7 @@ describe("node-html-to-image", () => {
     it("should return a buffer", async () => {
       const result = await nodeHtmlToImage({
         html: "<html></html>",
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(result).toBeInstanceOf(Buffer);
@@ -70,6 +73,7 @@ describe("node-html-to-image", () => {
         // @ts-ignore
         await nodeHtmlToImage({
           output: "./generated/image.png",
+          puppeteerArgs: { args: ['--no-sandbox'] }
         });
       }).rejects.toThrow();
       expect(mockConsoleErr).toHaveBeenCalledWith(
@@ -81,7 +85,8 @@ describe("node-html-to-image", () => {
       await expect(async () => {
         await nodeHtmlToImage({
           timeout: 500,
-          html: "<html></html>"
+          html: "<html></html>",
+          puppeteerArgs: { args: ['--no-sandbox'] }
         });
       }).rejects.toThrow();
       expect(mockConsoleErr).toHaveBeenCalledWith(
@@ -94,6 +99,7 @@ describe("node-html-to-image", () => {
         output: "./generated/image.jpg",
         html: "<html></html>",
         type: "jpeg",
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(existsSync("./generated/image.jpg")).toBe(true);
@@ -103,6 +109,7 @@ describe("node-html-to-image", () => {
       await nodeHtmlToImage({
         output: "./generated/image.png",
         html: "<html><body>Hello world!</body></html>",
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       const text = await getTextFromImage("./generated/image.png");
@@ -114,6 +121,7 @@ describe("node-html-to-image", () => {
         output: "./generated/image.png",
         html: "<html><body>Hello {{name}}!</body></html>",
         content: { name: "Yvonnick" },
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       const text = await getTextFromImage("./generated/image.png");
@@ -126,6 +134,7 @@ describe("node-html-to-image", () => {
         html: '<html><body>Hello <div id="section">{{name}}!</div></body></html>',
         content: { name: "Sangwoo" },
         selector: "div#section",
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       const text = await getTextFromImage("./generated/image.png");
@@ -143,6 +152,7 @@ describe("node-html-to-image", () => {
           { name: "Yvonnick", output: "./generated/image1.png" },
           { name: "World", output: "./generated/image2.png" },
         ],
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       const text1 = await getTextFromImage("./generated/image1.png");
@@ -158,6 +168,7 @@ describe("node-html-to-image", () => {
         quality: 300,
         html: "<html><body>Hello {{name}}!</body></html>",
         content: [{ name: "Yvonnick" }, { name: "World" }],
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(result?.[0]).toBeInstanceOf(Buffer);
@@ -175,6 +186,7 @@ describe("node-html-to-image", () => {
           },
           { output: "./generated/image2.png", selector: "div#section2" },
         ],
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       const text1 = await getTextFromImage("./generated/image1.png");
@@ -197,6 +209,7 @@ describe("node-html-to-image", () => {
         quality: 300,
         html: "<html><body>Hello {{name}}!</body></html>",
         content,
+        puppeteerArgs: { args: ['--no-sandbox'] }
       });
 
       expect(readdirSync("./generated")).toHaveLength(NUMBER_OF_IMAGES);
@@ -209,8 +222,8 @@ describe("node-html-to-image", () => {
       await nodeHtmlToImage({
         output: "./generated/image.png",
         html: "<html></html>",
-        puppeteerArgs: { executablePath },
-        puppeteer: puppeteerCore,
+        puppeteerArgs: { executablePath, args: ['--no-sandbox'] },
+        puppeteer: puppeteerCore
       });
 
       expect(existsSync("./generated/image.png")).toBe(true);
@@ -228,7 +241,7 @@ describe("node-html-to-image", () => {
   });
 });
 
-async function getTextFromImage(path) {
+async function getTextFromImage(path: string) {
   const worker = await createWorker();
   await worker.loadLanguage("eng");
   await worker.initialize("eng");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,28 @@ import { Cluster } from "puppeteer-cluster";
 
 import { Screenshot } from "./models/Screenshot";
 import { makeScreenshot } from "./screenshot";
-import { Options, ScreenshotParams } from "./types";
+import { Encoding, ScreenshotType, Options, ScreenshotParams, Content, ConditionalArray, ContentArrayItem, ContentObject } from "./types";
 
-export async function nodeHtmlToImage(options: Options) {
+/**
+ * Generates an image (or images) from HTML using Puppeteer, optionally supporting batch processing.
+ *
+ * @template TE - The encoding type mapped by 'encoding' parameter. Base64 or binary. Default: binary (undefined).
+ * @template TC - The content type mapped by 'content' parameter. Object (ContentObject) or Object Array (ContentArrayItem[]).
+ * @param options - Configuration options for HTML rendering and screenshot generation.
+ * @param options.html - The HTML string to render.
+ * @param options.encoding - The encoding for the output image(s).
+ * @param options.transparent - Whether the background should be transparent.
+ * @param options.content - Content data or array of content data for batch processing.
+ * @param options.output - Output file path if content is an Object. Else define output within the Content Array ContentArrayItem[].
+ * @param options.selector - CSS selector to target a specific element for screenshot if content is an Object. Else selector within the Content Array ContentArrayItem[].
+ * @param options.type - The image format. Options: 'png' (default), 'jpeg'
+ * @param options.quality - The image quality (for JPEG).
+ * @param options.puppeteerArgs - Puppeteer configuration options.
+ * @param options.timeout - Timeout for Puppeteer operations in MS (default: 30000ms/30s).
+ * @param options.puppeteer - Use a custom puppeteer library (i.e puppeteer-core or puppeteer-extra)
+ * @returns String or Buffer depending on encoding type. If content is an array it will return an Array instead of single a string or Buffer.
+ */
+export async function nodeHtmlToImage<TE extends Encoding | undefined = undefined, TC extends Content | undefined = undefined>(options: Options<TE, TC>): Promise<ConditionalArray<TC, ScreenshotType<TE>, ScreenshotType<TE>>> {
   const {
     html,
     encoding,
@@ -19,7 +38,7 @@ export async function nodeHtmlToImage(options: Options) {
     puppeteer = undefined,
   } = options;
 
-  const cluster: Cluster<ScreenshotParams> = await Cluster.launch({
+  const cluster: Cluster<ScreenshotParams<TE, ContentObject>> = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
     maxConcurrency: 2,
     timeout,
@@ -28,10 +47,10 @@ export async function nodeHtmlToImage(options: Options) {
   });
 
   const shouldBatch = Array.isArray(content);
-  const contents = shouldBatch ? content : [{ ...content, output, selector }];
+  const contents = (shouldBatch ? content : [{ ...content, output, selector }]) as ContentArrayItem[];
 
   try {
-    const screenshots: Array<Screenshot> = await Promise.all(
+    const screenshots: Array<Screenshot<TE, TC>> = await Promise.all(
       contents.map((content) => {
         const { output, selector: contentSelector, ...pageContent } = content;
         return cluster.execute(
@@ -48,7 +67,7 @@ export async function nodeHtmlToImage(options: Options) {
           async ({ page, data }) => {
             const screenshot = await makeScreenshot(page, {
               ...options,
-              screenshot: new Screenshot(data),
+              screenshot: new Screenshot<TE, ContentObject>(data),
             });
             return screenshot;
           },
@@ -58,9 +77,9 @@ export async function nodeHtmlToImage(options: Options) {
     await cluster.idle();
     await cluster.close();
 
-    return shouldBatch
+    return (shouldBatch
       ? screenshots.map(({ buffer }) => buffer)
-      : screenshots[0].buffer;
+      : screenshots[0].buffer) as ConditionalArray<TC, ScreenshotType<TE>, ScreenshotType<TE>>;
   } catch (err) {
     console.error(err);
     await cluster.close();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,20 +8,20 @@ import { Encoding, ScreenshotType, Options, ScreenshotParams, Content, Condition
  * Generates an image (or images) from HTML using Puppeteer, optionally supporting batch processing.
  *
  * @template TE - The encoding type mapped by 'encoding' parameter. Base64 or binary. Default: binary (undefined).
- * @template TC - The content type mapped by 'content' parameter. Object (ContentObject) or Object Array (ContentArrayItem[]).
+ * @template TC - The content type mapped by 'content' parameter. This is either an object or object[].
  * @param options - Configuration options for HTML rendering and screenshot generation.
  * @param options.html - The HTML string to render.
  * @param options.encoding - The encoding for the output image(s).
  * @param options.transparent - Whether the background should be transparent.
  * @param options.content - Content data or array of content data for batch processing.
- * @param options.output - Output file path if content is an Object. Else define output within the Content Array ContentArrayItem[].
- * @param options.selector - CSS selector to target a specific element for screenshot if content is an Object. Else selector within the Content Array ContentArrayItem[].
+ * @param options.output - Output file path if content is an object. Else define output within the Content object[].
+ * @param options.selector - CSS selector to target a specific element for the screenshot if content is an object. Else declare the selector within the Content object[].
  * @param options.type - The image format. Options: 'png' (default), 'jpeg'
  * @param options.quality - The image quality (for JPEG).
  * @param options.puppeteerArgs - Puppeteer configuration options.
  * @param options.timeout - Timeout for Puppeteer operations in MS (default: 30000ms/30s).
  * @param options.puppeteer - Use a custom puppeteer library (i.e puppeteer-core or puppeteer-extra)
- * @returns String or Buffer depending on encoding type. If content is an array it will return an Array instead of single a string or Buffer.
+ * @returns String (base64) or Buffer (binary) depending on encoding type. If content is an array it will return an array instead of single a string or Buffer.
  */
 export async function nodeHtmlToImage<TE extends Encoding | undefined = undefined, TC extends Content | undefined = undefined>(options: Options<TE, TC>): Promise<ConditionalArray<TC, ScreenshotType<TE>, ScreenshotType<TE>>> {
   const {

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,8 +81,7 @@ export async function nodeHtmlToImage<TE extends Encoding | undefined = undefine
       ? screenshots.map(({ buffer }) => buffer)
       : screenshots[0].buffer) as ConditionalArray<TC, ScreenshotType<TE>, ScreenshotType<TE>>;
   } catch (err) {
-    console.error(err);
     await cluster.close();
-    process.exit(1);
+    throw err;
   }
 }

--- a/src/main.unit.spec.ts
+++ b/src/main.unit.spec.ts
@@ -3,11 +3,11 @@ import { Cluster } from "puppeteer-cluster";
 
 import { Screenshot } from "./models/Screenshot";
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("node-html-to-image | Unit", () => {
-  let mockExit;
-  let launchMock;
+  let mockExit: jest.SpyInstance;
+  let launchMock: jest.SpyInstance;
   const buffer1 = Buffer.alloc(1);
   const buffer2 = Buffer.alloc(1);
   const html = "<html><body>{{message}}</body></html>";

--- a/src/models/Screenshot.spec.ts
+++ b/src/models/Screenshot.spec.ts
@@ -56,6 +56,7 @@ describe("Screenshot", () => {
     });
 
     expect(() => {
+      // @ts-expect-error html has to be a string
       screenshot.setHTML(null);
     }).toThrow("You must provide an html property.");
 
@@ -158,6 +159,7 @@ describe("Screenshot", () => {
 
   it("should throw an Error if html is null", () => {
     expect(() => {
+      // @ts-expect-error html has to be a string
       new Screenshot({ html: null });
     }).toThrow("You must provide an html property.");
   });

--- a/src/models/Screenshot.ts
+++ b/src/models/Screenshot.ts
@@ -1,17 +1,17 @@
-import { ImageType, Encoding, Content, ScreenshotParams } from "../types";
+import { ImageType, Encoding, Content, ScreenshotParams, ScreenshotType } from "../types";
 
-export class Screenshot {
+export class Screenshot<TE extends Encoding, TC extends Content> {
   output: string;
   content: Content;
   selector: string;
   html: string;
   quality?: number;
-  buffer?: Buffer | string;
+  buffer?: ScreenshotType<TE>;
   type?: ImageType;
   encoding?: Encoding;
   transparent?: boolean;
 
-  constructor(params: ScreenshotParams) {
+  constructor(params: ScreenshotParams<TE, TC>) {
     if (!params || !params.html) {
       throw Error("You must provide an html property.");
     }
@@ -45,7 +45,11 @@ export class Screenshot {
   }
 
   setBuffer(buffer: Buffer | string) {
-    this.buffer = buffer;
+    if (this.encoding === 'base64') {
+      this.buffer = (typeof buffer === 'string' ? buffer : buffer.toString('base64')) as ScreenshotType<TE>;
+    } else {
+      this.buffer = (typeof buffer === 'string' ? Buffer.from(buffer) : buffer) as ScreenshotType<TE>;
+    }
   }
 }
 

--- a/src/screenshot.spec.ts
+++ b/src/screenshot.spec.ts
@@ -4,7 +4,8 @@ import { makeScreenshot } from "./screenshot";
 import { Screenshot } from "./models/Screenshot";
 
 describe("beforeScreenshot", () => {
-  let page;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let page: any;
   const buffer = new ArrayBuffer();
 
   beforeEach(() => {
@@ -106,7 +107,8 @@ describe("beforeScreenshot", () => {
 });
 
 describe("handlebarsHelpers", () => {
-  let page;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let page: any;
   const buffer = new ArrayBuffer();
 
   beforeEach(() => {
@@ -119,11 +121,11 @@ describe("handlebarsHelpers", () => {
       Object.prototype.hasOwnProperty.call(handlebars.helpers, "equals") &&
       !!handlebars.helpers.equals
     ) {
-      handlebars.registerHelper({ equals: undefined });
+      delete handlebars.helpers.equals;
     }
   });
 
-  const compactHtml = (htmlString) => htmlString.replace(/((^|\n)\s+)/gm, "");
+  const compactHtml = (htmlString: string) => htmlString.replace(/((^|\n)\s+)/gm, "");
 
   describe("if no logic is given in the template", () => {
     const html = "<html><body><h1>Hello world!</h1></body></html>";
@@ -153,7 +155,7 @@ describe("handlebarsHelpers", () => {
         label: "all helpers are functions but no content is passed",
         options: {
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -164,7 +166,7 @@ describe("handlebarsHelpers", () => {
         options: {
           content: { myOtherVar: "bar" },
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -176,6 +178,7 @@ describe("handlebarsHelpers", () => {
         await expect(
           makeScreenshot(page, {
             screenshot: new Screenshot(test.options),
+            // @ts-expect-error typing not following conventions
             handlebarsHelpers: test.options.handlebarsHelpers,
           }),
         ).resolves.not.toThrow();
@@ -185,6 +188,7 @@ describe("handlebarsHelpers", () => {
         const p = jest.fn(() => page);
         await makeScreenshot(p(), {
           screenshot: new Screenshot(test.options),
+          // @ts-expect-error typing not following conventions
           handlebarsHelpers: test.options.handlebarsHelpers,
         });
         expect(p().setContent).toHaveBeenCalledWith(html, expect.anything());
@@ -195,7 +199,9 @@ describe("handlebarsHelpers", () => {
       await expect(
         makeScreenshot(page, {
           handlebarsHelpers: {
+            // @ts-expect-error undefined variable
             foo: () => myVar === "foo",
+            // @ts-expect-error typing not following conventions
             bar: "I'm not a valid function",
           },
           screenshot: new Screenshot({
@@ -246,7 +252,7 @@ describe("handlebarsHelpers", () => {
           "handlebarsHelpers is an object, but some helper is not a function",
         options: {
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
             bar: "I'm not a function",
           },
           html: html,
@@ -260,6 +266,7 @@ describe("handlebarsHelpers", () => {
         await expect(
           makeScreenshot(page, {
             screenshot: new Screenshot(test.options),
+            // @ts-expect-error typing not following conventions
             handlebarsHelpers: test.options.handlebarsHelpers,
           }),
         ).rejects.toThrow(test.error);
@@ -281,7 +288,7 @@ describe("handlebarsHelpers", () => {
         label: "all helpers are functions but no content is passed",
         options: {
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -292,7 +299,7 @@ describe("handlebarsHelpers", () => {
         options: {
           content: undefined,
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -304,7 +311,7 @@ describe("handlebarsHelpers", () => {
         options: {
           content: { myOtherVar: "bar" },
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -315,7 +322,7 @@ describe("handlebarsHelpers", () => {
         options: {
           content: { myVar: "foo" },
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },
@@ -333,7 +340,7 @@ describe("handlebarsHelpers", () => {
         options: {
           content: { myVar: "bar" },
           handlebarsHelpers: {
-            equals: (a, b) => a === b,
+            equals: (a: unknown, b: unknown) => a === b,
           },
           html: html,
         },

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -48,7 +48,7 @@ export async function makeScreenshot(
     quality: screenshot.quality,
   });
 
-  screenshot.setBuffer(Buffer.from(result));
+  screenshot.setBuffer(typeof result === 'string' ? result : Buffer.from(result));
 
   return screenshot;
 }

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -1,9 +1,9 @@
 import { Page } from "puppeteer";
 import handlebars, { compile } from "handlebars";
 
-import { MakeScreenshotParams } from "./types";
+import { ContentObject, Encoding, MakeScreenshotParams } from "./types";
 
-export async function makeScreenshot(
+export async function makeScreenshot<TE extends Encoding>(
   page: Page,
   {
     screenshot,
@@ -11,8 +11,8 @@ export async function makeScreenshot(
     waitUntil = "networkidle0",
     timeout,
     handlebarsHelpers,
-  }: MakeScreenshotParams,
-) {
+  }: MakeScreenshotParams<TE, ContentObject>,
+)  {
   page.setDefaultTimeout(timeout);
   const hasHelpers = handlebarsHelpers && typeof handlebarsHelpers === "object";
   if (hasHelpers) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,57 @@
 import type { Page, PuppeteerLifeCycleEvent, PuppeteerNodeLaunchOptions } from "puppeteer";
 import type { Screenshot } from "./models/Screenshot";
 
-export type Content = Array<{ output: string; selector?: string }> | object;
+// Content (ContentObject + ContentArrayItem) declares the possible formatting of the content object
+export type ContentObject = Record<string, unknown>;
+export type ContentArrayItem = {
+  output?: string;
+  selector?: string;
+} & Record<string, unknown>;
+export type Content = ContentObject | ContentArrayItem[];
+
+// Declares the type definitions of the captured image(s)
 export type Encoding = "base64" | "binary";
 export type ImageType = "png" | "jpeg";
 
-export interface ScreenshotParams {
+// Declares a mapping between response type and input types for captured images according to encoding type
+// Encoding base64 is a base64 string, 'binary' is a Buffer, and if none is specified 'binary' is default (Buffer)
+export type ScreenshotType<TE extends Encoding> = TE extends undefined ? Buffer : TE extends 'base64' ? string : Buffer;
+
+// TQ = array check, TA = resulting array type if TQ is an array, TO = resulting type if TQ isn't an array
+export type ConditionalArray<TQ, TA, TO> = TQ extends undefined ? TO : TQ extends Array<unknown> ? TA[] : TO;
+
+// Helper for the ContentArrayItem specifically since it has optional keys important for the image capture procedure
+// Ensures that the array type shows the default 'output' and 'selector' keys in code editors but simply returns
+// self (the declared object) if it isn't of type Array since these special keys then are taken from the parent object
+type EnsureArrayKeys<TA, TD> = TA extends (infer U)[] ? (U & TD)[] : TA;
+
+// Declares the parameters of the screenshot and automatically enables tracking according to declared TE (TypeEncoding) and TC (TypeContent)
+// TE and TC used for tracking since these key-values changes the response image type (TE = string/Buffer, TC = object or object[])
+export interface ScreenshotParams<TE extends Encoding, TC extends Content> {
   html: string;
-  encoding?: Encoding;
+  encoding?: TE;
   transparent?: boolean;
   type?: ImageType;
   quality?: number;
   selector?: string;
-  content?: Content;
+  content?: EnsureArrayKeys<TC, ContentArrayItem>;
   output?: string;
 }
 
-export interface Options extends ScreenshotParams {
+// Options for the Puppeteer cluster and also extends in the parameters for t he screenshot processing
+export interface Options<TE extends Encoding, TC extends Content> extends ScreenshotParams<TE, TC>, Omit<MakeScreenshotParams<TE, TC>, 'screenshot'> {
   puppeteerArgs?: PuppeteerNodeLaunchOptions;
   // https://github.com/thomasdondorf/puppeteer-cluster/blob/b5b098aed84b8d2c170b3f9d0ac050f53582df45/src/Cluster.ts#L30
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   puppeteer?: any,
-  waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-  beforeScreenshot?: (page: Page) => void;
-  timeout?: number
 }
 
-export interface MakeScreenshotParams {
-  screenshot: Screenshot;
+// Options for the underlying function which process the process and capture a single image via Puppeteer
+export interface MakeScreenshotParams<TE extends Encoding, TC extends Content> {
+  screenshot: Screenshot<TE, TC>;
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-  beforeScreenshot?: (page: Page) => void;
+  beforeScreenshot?: (page: Page) => void | Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handlebarsHelpers?: { [helpers: string]: (...args: any[]) => any };
 
   timeout?: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,6 +1078,30 @@
     update-notifier "^2.2.0"
     yargs "^8.0.2"
 
+"@isaacs/balanced-match@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
+  integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
+
+"@isaacs/brace-expansion@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz#4b3dabab7d8e75a429414a96bd67bf4c1d13e0f3"
+  integrity sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==
+  dependencies:
+    "@isaacs/balanced-match" "^4.0.1"
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1702,6 +1726,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1720,6 +1749,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -2399,6 +2433,15 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -2557,6 +2600,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -2579,6 +2627,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encoding@^0.1.11:
   version "0.1.13"
@@ -3023,6 +3076,14 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+foreground-child@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -3262,6 +3323,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
+  integrity sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==
+  dependencies:
+    foreground-child "^3.3.1"
+    jackspeak "^4.1.1"
+    minimatch "^10.0.3"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^2.0.0"
 
 glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -3856,6 +3929,13 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jackspeak@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.1.1.tgz#96876030f450502047fc7e8c7fcf8ce8124e43ae"
+  integrity sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
 
 java-properties@^1.0.0:
   version "1.0.2"
@@ -4554,6 +4634,11 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
+lru-cache@^11.0.0:
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.2.tgz#40fd37edffcfae4b2940379c0722dc6eeaa75f24"
+  integrity sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -4698,6 +4783,13 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.3.tgz#cf7a0314a16c4d9ab73a7730a0e8e3c3502d47aa"
+  integrity sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==
+  dependencies:
+    "@isaacs/brace-expansion" "^5.0.0"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -4726,6 +4818,11 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.9.0:
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
+
+minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 minizlib@^1.3.3:
   version "1.3.3"
@@ -5183,6 +5280,11 @@ pac-resolver@^7.0.1:
     degenerator "^5.0.0"
     netmask "^2.0.2"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 package-json@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
@@ -5304,6 +5406,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.0.tgz#9f052289f23ad8bf9397a2a0425e7b8615c58580"
+  integrity sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -5822,6 +5932,14 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
+  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
+  dependencies:
+    glob "^11.0.0"
+    package-json-from-dist "^1.0.0"
+
 run-async@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -5935,6 +6053,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 signale@^1.3.0:
   version "1.4.0"
@@ -6135,6 +6258,15 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -6161,6 +6293,15 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -6179,6 +6320,13 @@ stringify-package@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -6207,6 +6355,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -6763,6 +6918,15 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -6779,6 +6943,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
# Goal
Primary goal is to fix the issue where base64 strings incorrectly gets wrapped within a Buffer object.

On top of that providing some additional fixes with the typing to make the user experience better.

I did also notice that apps exit with code 1 (error). This would be a problem for most use cases of the library and therefore removed this from the catch clause of the function call.

To futher increase the user experience also added JS Doc for the exposed function, to give code editors context on the function and what parameters mean what.

Originally the following PR but re-created due to refactoring: https://github.com/frinyvonnick/node-html-to-image/pull/231

# Related issues
This PR does not only fix some issues that I have ran into, but after reviewing the code also found some other pitfalls which I have fixed.

https://github.com/frinyvonnick/node-html-to-image/issues/230
Issue raised by me regarding the base64 string issue, where it is always wrapped in a Buffer object instead of returning the base64 string similar to v4 of node-html-to-image

https://github.com/frinyvonnick/node-html-to-image/issues/228
Issue describing that the exposed `nodeHtmlToImage` function is missing handlebarsHelpers. In order to provide handlebarsHelpers you have to pass it without typing and mark it as i.e `@ts-expect-error`.

https://github.com/frinyvonnick/node-html-to-image/issues/165 | https://github.com/frinyvonnick/node-html-to-image/issues/221
These issues both describe an issue where they are unable to handle try-catch. This is due to the process.exit(1) leading a force close of the parent process.

# Changes
- Fix typing errors and warnings in spec files (test cases)
  - Update `rimraf` package since the current one didn't include typing declarations, but newer versions does
- Add `"--no-sandbox"` option to `puppeteerArgs.args` within all test cases since a lot of systems and enclosed systems doesn't support this sandboxing environment. The processed data is test case controlled and therefore safe either way so no negatives for the test cases
- Fix case where base64 strings during encoding mode base64 gets wrapped in a Buffer object. By this change following the same spec as v4.0.0 and the existing typing conventions.
- More advanced and dynamic typing according to provided options payload
  - Content option deep typing
  - Exposing apis properly via options (i.e handlebarsHelpers were missing). Via interface inheritance getting rid of duplicated declarations which prevents conflicts and missing options.
  - Dynamic return type recognition according to options payload. Previously the return type no matter what was a union return type `string | Buffer | (string | Buffer)[]`. Now it will be one of the following and always only one which is declared via the provided options payload: `string`, `Buffer`, `string[]`, `Buffer[]`
  - JS Doc on the exposed function (`nodeHtmlToImage`), leading to easier use for end users
- Remove the case where throws close down the entire app entirely, leading to parent applications unexpectedly shutting down without any type of feedback. Now it will simply throw, but safely close down the cluster via a catch still.


Thank you for providing us all this open source library!

Best regards and wishes,
Yazaar / Jesper